### PR TITLE
QtGUI

### DIFF
--- a/util/loadSetting.py
+++ b/util/loadSetting.py
@@ -83,6 +83,10 @@ COLORS=#DAC177,#DF7567,#50AFC8,#74A15F,#BEBEBE,#BAB9A1,#E4D0AA
 ; 按键触发速度设置
 DELAY_MIN=0.03
 DELAY_MAX=0.08
+
+; GUI相关设置
+; GUI是否应该随着程序启动，接受值: 1, 0
+START_GUI_WITH_PROGRAM=1
 '''
 
 def getDefaultConfigDict() -> dict:

--- a/util/settingGUI.py
+++ b/util/settingGUI.py
@@ -1,12 +1,12 @@
 import os
 
 from util.globalHotKeyManager import GlobalHotKeyManager, vk_to_key_str
-from util.loadSetting import saveConfigDict
+from util.loadSetting import saveConfigDict, getConfigDict, getDefaultConfigDict
 from util.imageProcessing import capture_screenshot, crop_image, resize_image
 
 from PyQt6.QtWidgets import QApplication, QWidget, QDoubleSpinBox, QLabel, QPushButton, QTextEdit, QMessageBox
 from PyQt6.QtGui import QKeyEvent, QColor, QPainter, QBrush, QPen, QDesktopServices
-from PyQt6.QtCore import Qt, QPoint, QUrl
+from PyQt6.QtCore import Qt, QPoint, QUrl, QTimer
 
 
 class resizePanel(QWidget):
@@ -28,8 +28,9 @@ class resizePanel(QWidget):
             Qt.WindowType.WindowStaysOnTopHint |
             Qt.WindowType.Tool
         )
-
         self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
+        self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose)
+        self.setMouseTracking(True)
 
         self.resize(max(self.min_w, w), max(self.min_h, h))
         self.move(x, y)
@@ -89,18 +90,37 @@ class resizePanel(QWidget):
         self.drag_position = event.globalPosition().toPoint()
 
     def mouseMoveEvent(self, event):
-        if not self.resizing:
+
+        # cursor shape change
+        pos = event.position().toPoint()
+        half_w = self.width() // 2
+        half_h = self.height() // 2
+
+        shouldSetCursor = True
+        # cursor not on resize place
+        if pos.x() <= half_w or pos.y() <= half_h:
+            shouldSetCursor = False
+        # cursor on the save button
+        if self.save_button.geometry().contains(pos):
+            shouldSetCursor = False
+        # should always keep resize cursor shape when resizing
+        if self.resizing:
+            shouldSetCursor = True
+
+        if shouldSetCursor:
+            self.setCursor(Qt.CursorShape.SizeFDiagCursor)
+        else:
+            self.setCursor(Qt.CursorShape.ArrowCursor)
+
+        # window resize
+        if not self.resizing or not self.resize_corner:
             return
 
         current_pos = event.globalPosition().toPoint()
         delta = current_pos - self.drag_position
 
-        new_w = self.geometry().width()
-        new_h = self.geometry().height()
-        if self.resize_corner:
-            new_w += delta.x()
-            new_h += delta.y()
-
+        new_w = self.width() + delta.x()
+        new_h = self.height() + delta.y()
 
         self.resize(max(self.min_w, new_w), max(self.min_h, new_h))
         self.drag_position = current_pos
@@ -114,15 +134,17 @@ class settingPanel(QWidget):
 
     qApp = None
     config = None
-    keyMgr = None
+
+    reset_button = None
 
     save_button = None
+
+    manual_edit_button = None
 
     delay_min_spinbox = None
     delay_max_spinbox = None
 
     keybind_button = None
-    keybind_label = None
     onGettingKeys = False
     #TODO: for multi key support
     #onHoldKeys = []
@@ -140,56 +162,73 @@ class settingPanel(QWidget):
 
         self.qApp = qApp
         self.config = config
-        self.keyMgr = hotkeyManager
 
-        self.setFixedSize(200, 300)
+        self.setFixedSize(200, 320)
+
+        self.initWidgets()
+
+    def initWidgets(self):
+
+        # reset button #
+
+        self.save_button = QPushButton("重置所有设置", self)
+        self.save_button.setGeometry(10, 280, 85, 30)
+        self.save_button.setStyleSheet("color: red;")
+
+        self.save_button.clicked.connect(self.onResetButtonCliecked)
+
+        # reset button end #
 
         # save button #
 
-        self.save_button = QPushButton("保存", self)
-        self.save_button.setGeometry(10, 260, 180, 30)
+        self.save_button = QPushButton("保存所有设置", self)
+        self.save_button.setGeometry(105, 280, 85, 30)
 
         self.save_button.clicked.connect(self.onSaveButtonCliecked)
 
         # save button end #
 
+        # manual edit button #
+
+        self.manual_edit_button = QPushButton("（高级）手动编辑配置文件", self)
+        self.manual_edit_button.setGeometry(10, 245, 180, 30)
+
+        self.manual_edit_button.clicked.connect(self.onManualEditButtonCliecked)
+
+        # manual edit button #
+
         # spinbox #
 
         def createSpinbox_delay(label, h):
             delay_label = QLabel(label, self)
-            delay_label.setGeometry(10, h, 100, 30)
+            delay_label.setGeometry(10, h, 120, 30)
 
             delay_spinbox = QDoubleSpinBox(self)
-            delay_spinbox.setGeometry(110, h, 80, 30)
+            delay_spinbox.setGeometry(130, h, 60, 30)
 
             delay_spinbox.setRange(0.0, 100.0)
-            delay_spinbox.setDecimals(2)
-            delay_spinbox.setSingleStep(0.01)
+            delay_spinbox.setDecimals(3)
+            delay_spinbox.setSingleStep(0.001)
 
             return delay_spinbox
 
         # DELAY_MIN #
 
-        self.delay_min_spinbox = createSpinbox_delay("最小延迟 (秒):", 10)
-        self.delay_min_spinbox.setValue(float(self.config.get("DELAY_MIN", "0.05")))
+        self.delay_min_spinbox = createSpinbox_delay("按键随机最小延迟(s):", 10)
+        self.delay_min_spinbox.setValue(float(self.config.get("DELAY_MIN", "")))
 
-        # DELAY_MAX
+        # DELAY_MAX #
 
-        self.delay_max_spinbox = createSpinbox_delay("最大延迟 (秒):", 40)
-        self.delay_max_spinbox.setValue(float(self.config.get("DELAY_MAX", "0.1")))
+        self.delay_max_spinbox = createSpinbox_delay("按键随机最大延迟(s):", 40)
+        self.delay_max_spinbox.setValue(float(self.config.get("DELAY_MAX", "")))
 
         # spinbox end #
 
         # keybind #
 
-        self.keybind_button = QPushButton("更改按键", self)
-        self.keybind_button.setGeometry(110, 80, 80, 30)
+        self.keybind_button = QPushButton("配置键盘快捷键", self)
+        self.keybind_button.setGeometry(10, 75, 180, 30)
         self.keybind_button.clicked.connect(self.onKeybindButtonCliecked)
-
-        self.keybind_label = QTextEdit(self)
-        self.keybind_label.setGeometry(10, 80, 90, 30)
-        self.keybind_label.setReadOnly(True)
-        self.keybind_label.setPlainText(self.config.get("ACTIVATION", "<ctrl>"))
 
         # keybind end #
 
@@ -204,9 +243,9 @@ class settingPanel(QWidget):
 
             delay_spinbox = QDoubleSpinBox(self)
             if first:
-                delay_spinbox.setGeometry(40, h, 55, 30)
+                delay_spinbox.setGeometry(35, h, 60, 30)
             else:
-                delay_spinbox.setGeometry(135, h, 55, 30)
+                delay_spinbox.setGeometry(130, h, 60, 30)
 
             delay_spinbox.setRange(0.0, 99999.0)
             delay_spinbox.setDecimals(0)
@@ -215,32 +254,61 @@ class settingPanel(QWidget):
             return delay_spinbox
 
         resize_label = QLabel("========  识别区域设置  ========", self)
-        resize_label.setGeometry(10, 120, 180, 30)
+        resize_label.setGeometry(10, 110, 180, 25)
         resize_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
 
-        self.size_x_spinbox = createSpinbox_resizePanel( "左:", 150, True )
-        self.size_x_spinbox.setValue(float(self.config.get("LEFT", "30")))
+        self.size_x_spinbox = createSpinbox_resizePanel( "左:", 135, True )
+        self.size_x_spinbox.setValue(float(self.config.get("LEFT", "")))
 
-        self.size_y_spinbox = createSpinbox_resizePanel( "上:", 185, True )
-        self.size_y_spinbox.setValue(float(self.config.get("TOP", "20")))
+        self.size_y_spinbox = createSpinbox_resizePanel( "上:", 165, True )
+        self.size_y_spinbox.setValue(float(self.config.get("TOP", "")))
 
-        self.size_w_spinbox = createSpinbox_resizePanel( "右:", 150, False )
-        self.size_w_spinbox.setValue(float(self.config.get("RIGHT", "220")))
+        self.size_w_spinbox = createSpinbox_resizePanel( "右:", 135, False )
+        self.size_w_spinbox.setValue(float(self.config.get("RIGHT", "")))
 
-        self.size_h_spinbox = createSpinbox_resizePanel( "下:", 185, False )
-        self.size_h_spinbox.setValue(float(self.config.get("BOTTOM", "400")))
+        self.size_h_spinbox = createSpinbox_resizePanel( "下:", 165, False )
+        self.size_h_spinbox.setValue(float(self.config.get("BOTTOM", "")))
 
         self.resize_button = QPushButton("交互式更改", self)
-        self.resize_button.setGeometry(10, 220, 85, 30)
+        self.resize_button.setGeometry(10, 200, 85, 30)
         self.resize_button.clicked.connect(self.onResizeButtonCliecked)
 
         self.resize_test_button = QPushButton("截图测试", self)
-        self.resize_test_button.setGeometry(105, 220, 85, 30)
+        self.resize_test_button.setGeometry(105, 200, 85, 30)
         self.resize_test_button.clicked.connect(self.onResizeTestButtonCliecked)
 
         # resize panel end #
 
+
+    # reset button #
+    def onResetButtonCliecked(self):
+        message_box = QMessageBox(self)
+        message_box.setWindowTitle("二次确认")
+        message_box.setText("你正在执行的操作：重置所有设置<br/><font color='red'>警告：此操作不可逆</font>")
+        message_box.setStandardButtons(QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No)
+        message_box.setDefaultButton(QMessageBox.StandardButton.No)
+        message_box.button(QMessageBox.StandardButton.Yes).setText("确认")
+        message_box.button(QMessageBox.StandardButton.No).setText("取消")
+        message_box.setIcon(QMessageBox.Icon.Warning)
+
+        reply = message_box.exec()
+        if reply == QMessageBox.StandardButton.No:
+            return
+
+
+        saveConfigDict(getDefaultConfigDict())
+        self.config = getConfigDict()
+
+        # delete all Widgets and reinit them, so i dont need to change the widgets value one by one
+        self.hide()
+
+        for child in self.findChildren(QWidget):
+            child.deleteLater()
+        self.initWidgets()
+
+        self.show()
+    # reset button end #
 
     # save button #
     def onSaveButtonCliecked(self):
@@ -257,11 +325,23 @@ class settingPanel(QWidget):
         }
 
         saveConfigDict(newConfig)
+        self.config = getConfigDict()
+
         self.close()
     # save button end #
 
+    # manual edit button #
+    def onManualEditButtonCliecked(self):
+        QDesktopServices.openUrl(QUrl.fromLocalFile('./config.ini'))
+        # wait for a while to let QDesktopServices finish his job
+        QTimer.singleShot(1000, self.close)
+    # manual edit button end #
+
     # keybind #
     def onKeybindButtonCliecked(self):
+        return
+
+    """
         #TODO: for multi key support
         # defensive fix
         #self.onHoldKeys = []
@@ -288,6 +368,7 @@ class settingPanel(QWidget):
         #self.onHoldKeys = []
         self.releaseKeyboard()
         self.onGettingKeys = False
+    """
     # keybind end #
 
     # resize panel #
@@ -308,7 +389,7 @@ class settingPanel(QWidget):
     def onResizeButtonCliecked(self):
 
         # EDIT: well we just find out that this software can not even run on wayland, and this tips is useless now
-        # can not get overlayWindow`s position at wayland environment, so this feat is fucked on wayland
+        # can not get overlayWindow position at wayland environment, so this feat is fucked on wayland
         #if os.environ.get('WAYLAND_DISPLAY') is not None:
         #    QMessageBox.critical(self, 'Error', 'Wayland环境下无法使用此功能', QMessageBox.StandardButton.Ok)
         #    return
@@ -320,19 +401,20 @@ class settingPanel(QWidget):
 
         screen_size = self.qApp.primaryScreen().size()
         sw, sh = screen_size.width(), screen_size.height()
-        # reverse imageProcessing format
+        # convert imageProcessing format to absolute position
         x, y = self.reverse_scale_coordinate((sw, sh), (x, y))
         w, h = self.reverse_scale_coordinate((sw, sh), (w, h))
         # make absolute position to window size
         w, h = w - x, h - y
 
         self.overlay = resizePanel(self, int(x), int(y), int(w), int(h))
+        self.overlay.destroyed.connect(self.onOverlayWindowDestroyed)
         self.overlay.show()
 
     def onResizeSaved(self):
         x, y, w, h = self.overlay.geometry().getRect()
         # change window size to absolute position
-        w, h = x + w, y + h # type: ignore
+        w, h = x + w, y + h
 
         # EDIT: haha i cant fix that, no help at all
         # linux wayland desktop defensive fix, fucking wayland destroy everything
@@ -344,7 +426,7 @@ class settingPanel(QWidget):
 
         screen_size = self.qApp.primaryScreen().size()
         sw, sh = screen_size.width(), screen_size.height()
-        # scale the to same format with imageProcessing
+        # scale to same format with imageProcessing
         x, y = self.scale_coordinate((sw, sh), (x, y))
         w, h = self.scale_coordinate((sw, sh), (w, h))
 
@@ -354,9 +436,13 @@ class settingPanel(QWidget):
         self.size_h_spinbox.setValue(h)
 
         self.overlay.close()
+
+    def onOverlayWindowDestroyed(self):
+        if self.isVisible():
+            return
         self.show()
 
-    # scale the to same format with imageProcessing
+    # scale to same format with imageProcessing
     def scale_coordinate(self, original_resolution, original_point):
         original_width, original_height = original_resolution
         if original_height == 0:
@@ -366,7 +452,7 @@ class settingPanel(QWidget):
         new_y = original_point[1] * scale
         return (new_x, new_y)
 
-    # reverse imageProcessing format
+    # convert imageProcessing format to absolute position
     def reverse_scale_coordinate(self, original_resolution, scaled_point):
         original_width, original_height = original_resolution
         if original_height == 0:
@@ -378,13 +464,15 @@ class settingPanel(QWidget):
     # resize panel end #
 
 # class from old tkGui(early nuked), im too lazy so i didnt change the api format #
-
 class settingsGUI:
 
     app = None
     window = None
+    config = None
 
     def __init__(self, config: dict, hotkeyManager: GlobalHotKeyManager):
+        self.config = config
+
         app = QApplication([])
         self.app = app
 
@@ -392,9 +480,16 @@ class settingsGUI:
         self.window = window
 
     def open_settings_gui(self):
+        if self.window.isVisible():
+            return
+
         self.window.show()
 
         if os.environ.get('WAYLAND_DISPLAY') is not None:
             QMessageBox.critical(self.window, 'Error', '此软件无法在Wayland环境下使用\n详见：\nhttps://github.com/BoboTiG/python-mss/issues/155', QMessageBox.StandardButton.Ok)
 
         self.app.exec()
+
+    def startWithProgram(self):
+        if bool(int(self.config.get("START_GUI_WITH_PROGRAM", ""))):
+            self.open_settings_gui()

--- a/util/settingGUI.py
+++ b/util/settingGUI.py
@@ -4,7 +4,7 @@ from util.globalHotKeyManager import GlobalHotKeyManager, vk_to_key_str
 from util.loadSetting import saveConfigDict, getConfigDict, getDefaultConfigDict
 from util.imageProcessing import capture_screenshot, crop_image, resize_image
 
-from PyQt6.QtWidgets import QApplication, QWidget, QDoubleSpinBox, QLabel, QPushButton, QTextEdit, QMessageBox
+from PyQt6.QtWidgets import QApplication, QWidget, QDoubleSpinBox, QLabel, QPushButton, QTextEdit, QMessageBox, QCheckBox
 from PyQt6.QtGui import QKeyEvent, QColor, QPainter, QBrush, QPen, QDesktopServices
 from PyQt6.QtCore import Qt, QPoint, QUrl, QTimer
 
@@ -139,6 +139,8 @@ class settingPanel(QWidget):
 
     save_button = None
 
+    start_with_program_checkbox = None
+
     manual_edit_button = None
 
     delay_min_spinbox = None
@@ -163,7 +165,7 @@ class settingPanel(QWidget):
         self.qApp = qApp
         self.config = config
 
-        self.setFixedSize(200, 320)
+        self.setFixedSize(200, 350)
 
         self.initWidgets()
 
@@ -172,7 +174,7 @@ class settingPanel(QWidget):
         # reset button #
 
         self.save_button = QPushButton("重置所有设置", self)
-        self.save_button.setGeometry(10, 280, 85, 30)
+        self.save_button.setGeometry(10, 310, 85, 30)
         self.save_button.setStyleSheet("color: red;")
 
         self.save_button.clicked.connect(self.onResetButtonCliecked)
@@ -182,20 +184,27 @@ class settingPanel(QWidget):
         # save button #
 
         self.save_button = QPushButton("保存所有设置", self)
-        self.save_button.setGeometry(105, 280, 85, 30)
+        self.save_button.setGeometry(105, 310, 85, 30)
 
         self.save_button.clicked.connect(self.onSaveButtonCliecked)
 
         # save button end #
 
+        # start with program #
+
+        self.start_with_program_checkbox = QCheckBox("允许设置面板随程序开启", self)
+        self.start_with_program_checkbox.setGeometry(10, 250, 180, 20)
+        self.start_with_program_checkbox.setChecked(bool(int(self.config.get("START_GUI_WITH_PROGRAM", ""))))
+        # this checkbox state will be saved when save button cliecked
+
+        # start with program end #
+
         # manual edit button #
 
         self.manual_edit_button = QPushButton("（高级）手动编辑配置文件", self)
-        self.manual_edit_button.setGeometry(10, 245, 180, 30)
+        self.manual_edit_button.setGeometry(10, 275, 180, 30)
 
-        self.manual_edit_button.clicked.connect(self.onManualEditButtonCliecked)
-
-        # manual edit button #
+        # manual edit button end #
 
         # spinbox #
 
@@ -316,12 +325,14 @@ class settingPanel(QWidget):
         newConfig = {
             "DELAY_MIN": self.delay_min_spinbox.value(),
             "DELAY_MAX": self.delay_max_spinbox.value(),
-            "ACTIVATION": self.keybind_label.toPlainText(),
+            #"ACTIVATION": self.keybind_label.toPlainText(),
 
             "LEFT": self.size_x_spinbox.value(),
             "TOP": self.size_y_spinbox.value(),
             "RIGHT": self.size_w_spinbox.value(),
-            "BOTTOM": self.size_h_spinbox.value()
+            "BOTTOM": self.size_h_spinbox.value(),
+
+            "START_GUI_WITH_PROGRAM": "1" if self.start_with_program_checkbox.isChecked() else "0"
         }
 
         saveConfigDict(newConfig)


### PR DESCRIPTION
- [x] resizePanel::mouseMoveEvent()在处于drag window时没有有效操作，检查是否应该直接return不做任何事
- [x] 通过新的获取默认值api来获取默认值，增加一键重设设置的按钮
- [x] 新增手动编辑按钮，按下后打开config.ini
- [x] 交互式窗口在鼠标移动到右下段时更改指针样式，提示用户可以操作
- [x] overlayWindow需要避免可能的意外关闭或者主窗口意外打开 
- [x] 启动时默认自动显示设置面板,可以设置不自动显示
  - [ ]  @GDNDZZK 在程序init后合适时机调用：settingsGUI::startWithProgram(self)
- [ ] 兼容新的按键绑定设置项

<br/>

#### feature

- [ ] 对于二值化设置，新增菜单，label为高级设置，阈值使用滑块，颜色使用QTextEdit
- [ ] wayland下运行的问题
- [ ] 使用scancode而非vk，支持检测左右modifiers